### PR TITLE
Require normal image when hDPI version is provided

### DIFF
--- a/.github/workflows/validate/validate.sh
+++ b/.github/workflows/validate/validate.sh
@@ -42,6 +42,15 @@ while read image; do
     [[ "${type}" != "PNG" ]] \
       && error "${image}" "Invalid file type '${type}' for file"
 
+    # Ensure normal version exists when hDPI image is provided
+    [[ "${filename}" == "icon@2x.png" ]] \
+      && [[ ! -f "${folderpath}/icon.png" ]] \
+        && error "${image}" "hDPI icon was provided, but the normal version is missing"
+
+    [[ "${filename}" == "logo@2x.png" ]] \
+      && [[ ! -f "${folderpath}/logo.png" ]] \
+        && error "${image}" "hDPI logo was provided, but the normal version is missing"
+
     # Validate image dimensions
     if [[ "${filename}" == "icon.png" ]]; then
       # icon dimension


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request.
-->

Providing just a hDPI version of an image is weird since the normal version would be just a resized version. It also gives some unexpected behavior in our case, since we assume the normal version exists.

This PR adjusts the validate action to ensure the normal version of images exists when the hDPI version is found.

Inspired by PR #59

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant Brands?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Add a new logo or icon for a new integration
- [ ] Add a missing icon or logo for an existing integration
- [ ] Replace an exiting icon or logo with a higher quality version
- [ ] Removing an icon or logo

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- Link to code base pull request: 
- Link to documentation pull request: 
- Link to integration documentation on our website: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your contribution.
-->

- [ ] The added/replaced image(s) are **PNG**
- [ ] Icon image size is 256x256px (`icon.png`)
- [ ] hDPI icon image size is 512x512px for  (`icon@2x.png`)
- [ ] Logo image size has min 128px, but max 256px, on the shortest side (`logo.png`)
- [ ] hDPI logo image size has min 256px, but max 512px, on the shortest side (`logo@2x.png`)

<!--
  Thank you for contributing <3
-->
