### PR TITLE
Docs: Add info cache release in major versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,8 @@ cache on the client-side and are cached for 1 hour on Cloudflare. This allows
 us to replace placeholder images within an acceptable time frame without losing
 our cache.
 
+Image additions and changes may take time to take effect due to caching. The cache is fully flushed in each major version of Home Assistant Core.
+
 ## Image specification
 
 All images must have the following requirements:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request.
-->
Inclusion of cache release information in each major version of the core.

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant Brands?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Add a new logo or icon for a new core integration
- [ ] Add a missing icon or logo for an existing core integration
- [ ] Add a new logo or icon for a custom integration (custom component)
  - [ ] I've opened up a PR for my custom integration on the [Home Assistant
    Python wheels repository](https://github.com/home-assistant/wheels-custom-integrations)
- [ ] Replace an existing icon or logo with a higher quality version
- [ ] Removing an icon or logo

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- Link to code base pull request: 
- Link to documentation pull request: 
- Link to integration documentation on our website: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your contribution.
-->

- [ ] The added/replaced image(s) are **PNG**
- [ ] Icon image size is 256x256px (`icon.png`)
- [ ] hDPI icon image size is 512x512px for  (`icon@2x.png`)
- [ ] Logo image size has min 128px, but max 256px, on the shortest side (`logo.png`)
- [ ] hDPI logo image size has min 256px, but max 512px, on the shortest side (`logo@2x.png`)

<!--
  Thank you for contributing <3
-->
