### PR TITLE
add symlink for new MVG integration

### DIFF
--- a/core_integrations/mvgapi
+++ b/core_integrations/mvgapi
@@ -1,0 +1,1 @@
+mvglive


### PR DESCRIPTION
## Proposed change

Add an icon and a logo for the new MVG integration in development `mvgapi` (see core issue 81760). This change proposes just a symlink for now; the existing logo from the broken `mvglive` is perfectly fine and may be renamed after migration phase.

## Type of change

- [X] Add a new logo or icon for a new core integration
- [ ] Add a missing icon or logo for an existing core integration
- [ ] Add a new logo or icon for a custom integration (custom component)
  - [ ] I've opened up a PR for my custom integration on the [Home Assistant
    Python wheels repository](https://github.com/home-assistant/wheels-custom-integrations)
- [ ] Replace an existing icon or logo with a higher quality version
- [ ] Removing an icon or logo

## Additional information

- Link to related issue for core integration: [#81760](https://github.com/home-assistant/core/issues/81760)

## Checklist

- [X] The added/replaced image(s) are **PNG**
- [X] Icon image size is 256x256px (`icon.png`)
- [X] hDPI icon image size is 512x512px for  (`icon@2x.png`)
- [X] Logo image size has min 128px, but max 256px, on the shortest side (`logo.png`)
- [X] hDPI logo image size has min 256px, but max 512px, on the shortest side (`logo@2x.png`)