### PR TITLE
Icon for new pid_thermostat integration.

### DIFF
--- a/core_integrations/pid_thermostat/icon.txt
+++ b/core_integrations/pid_thermostat/icon.txt
@@ -1,1 +1,1 @@
-mdi:pid_thermostat
+mdi:thermostat

--- a/core_integrations/pid_thermostat/icon.txt
+++ b/core_integrations/pid_thermostat/icon.txt
@@ -1,0 +1,1 @@
+mdi:pid_thermostat


### PR DESCRIPTION
## Proposed change
Add icon for new integration pid_thermostat. 

Issue for mdi icon is here: https://github.com/Templarian/MaterialDesign/issues/7106

## Type of change
- [x] Add a new logo or icon for a new core integration
- [ ] Add a missing icon or logo for an existing core integration
- [ ] Add a new logo or icon for a custom integration (custom component)
  - [ ] I've opened up a PR for my custom integration on the [Home Assistant
    Python wheels repository](https://github.com/home-assistant/wheels-custom-integrations)
- [ ] Replace an existing icon or logo with a higher quality version
- [ ] Removing an icon or logo

## Additional information
- This PR fixes or closes issue: fixes #
- Link to code base pull request: will follow
- Link to documentation pull request: will follow
- Link to integration documentation on our website: 

## Checklist

- [ ] The added/replaced image(s) are **PNG**
- [ ] Icon image size is 256x256px (`icon.png`)
- [ ] hDPI icon image size is 512x512px for  (`icon@2x.png`)
- [ ] Logo image size has min 128px, but max 256px, on the shortest side (`logo.png`)
- [ ] hDPI logo image size has min 256px, but max 512px, on the shortest side (`logo@2x.png`)
