### PR TITLE
Add icon for `bluetooth_speaker` integration

### DIFF
--- a/custom_integrations/bluetooth_speaker/icon.txt
+++ b/custom_integrations/bluetooth_speaker/icon.txt
@@ -1,0 +1,1 @@
+mdi:speaker-bluetooth


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request.
-->
Add an icon for the `bluetooth_speaker` integration that allows (/will allow) connecting Bluetooth speakers to the Home Assistant server. Currently developed as a custom integration at [`cr7pt0gr4ph7/homeassistant-bluetooth-speaker`](https://github.com/cr7pt0gr4ph7/homeassistant-bluetooth-speaker) with the intent of becoming a core integration once mature. See also the discussion at home-assistant/plugin-audio#193.

This simply uses the `mdi:speaker-bluetooth` icon.

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant Brands?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Add a new logo or icon for a new core integration
- [ ] Add a missing icon or logo for an existing core integration
- [X] Add a new logo or icon for a custom integration (custom component)
  - [X] I've added a link to my custom integration repository in the PR description
- [ ] Replace an existing icon or logo with a higher quality version
- [ ] Replace an existing icon or logo after a branding change
- [ ] Removing an icon or logo

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- Link to code base pull request: (Not yet applicable)
- Link to documentation pull request: (Not yet applicable)
- Link to integration documentation on our website: (Not yet applicable)
- Link to custom integration repository: https://github.com/cr7pt0gr4ph7/homeassistant-bluetooth-speaker

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your contribution.
-->

**Note:** This PR does not introduce a new image but simply reuses an existing MDI icon, in the same way as [`core_integrations/bluetooth`](https://github.com/home-assistant/brands/tree/master/core_integrations/bluetooth), so none of the items below seem to apply.

- [ ] The added/replaced image(s) are **PNG**
- [ ] Icon image size is 256x256px (`icon.png`)
- [ ] hDPI icon image size is 512x512px for  (`icon@2x.png`)
- [ ] Logo image size has min 128px, but max 256px, on the shortest side (`logo.png`)
- [ ] hDPI logo image size has min 256px, but max 512px, on the shortest side (`logo@2x.png`)

<!--
  Thank you for contributing <3
-->
