### PR TITLE
Add PR template option for supported brand assets

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -19,6 +19,7 @@
 
 - [ ] Add a new logo or icon for a new core integration
 - [ ] Add a missing icon or logo for an existing core integration
+- [ ] Add a new logo or icon for a new supported brand of an existing integration
 - [ ] Add a new logo or icon for a custom integration (custom component)
   - [ ] I've added a link to my custom integration repository in the PR description
 - [ ] Replace an existing icon or logo with a higher quality version


### PR DESCRIPTION
## Proposed change

Adds a new "Type of change" option to the PR template to better categorize contributions that add brand assets for newly supported brands of existing integrations.

## Type of change

- [x] Other (improvement to repository tooling)

## Problem

The current PR template doesn't have a fitting "Type of change" option for when contributors add icons/logos for new supported brands of existing integrations. This is different from:
- Adding assets for entirely new integrations
- Adding missing assets for existing integrations  
- Adding assets for custom integrations

Contributors working on supported brand assets (like in the `core_brands` directory) had to use less appropriate options, making categorization unclear for maintainers.

## Solution

Added a new checkbox option: