### PR TITLE
Add MDI based icon for new integration School Holiday

### DIFF
--- a/core_integrations/school_holiday/icon.txt
+++ b/core_integrations/school_holiday/icon.txt
@@ -1,0 +1,1 @@
+mdi:school


### PR DESCRIPTION
## Proposed change

This PR adds the MDI based icon for the new integration School Holiday.

## Type of change

- [x] Add a new logo or icon for a new core integration
- [ ] Add a missing icon or logo for an existing core integration
- [ ] Replace an existing icon or logo with a higher quality version
- [ ] Replace an existing icon or logo after a branding change
- [ ] Removing an icon or logo

## Additional information

- This PR fixes or closes issue: fixes #
- Link to code base pull request: https://github.com/home-assistant/core/pull/164611
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/43876
- Link to integration documentation on our website: 

## Checklist

- [ ] The added/replaced image(s) are **PNG**
- [ ] Icon image size is 256x256px (`icon.png`)
- [ ] hDPI icon image size is 512x512px for  (`icon@2x.png`)
- [ ] Logo image size has min 128px, but max 256px, on the shortest side (`logo.png`)
- [ ] hDPI logo image size has min 256px, but max 512px, on the shortest side (`logo@2x.png`)