### PR TITLE
Add radio_frequency integration

### DIFF
--- a/core_integrations/radio_frequency/icon.txt
+++ b/core_integrations/radio_frequency/icon.txt
@@ -1,0 +1,1 @@
+mdi:video-input-antenna


### PR DESCRIPTION
Add the `radio_frequency` core integration with `mdi:video-input-antenna` as its icon.

- Parent core PR: https://github.com/home-assistant/core/pull/168447
- Docs PR: https://github.com/home-assistant/home-assistant.io/pull/44828