### PR TITLE
Add honeywell_string_lights integration

### DIFF
--- a/core_integrations/honeywell_string_lights
+++ b/core_integrations/honeywell_string_lights
@@ -1,0 +1,1 @@
+honeywell


### PR DESCRIPTION
Add the `honeywell_string_lights` core integration as a symlink to the existing `honeywell` brand.

- Parent core PR: https://github.com/home-assistant/core/pull/168450
- Docs PR: https://github.com/home-assistant/home-assistant.io/pull/44829