### PR TITLE
Add marantz_infrared symlink to existing marantz brand

### DIFF
--- a/core_integrations/marantz_infrared
+++ b/core_integrations/marantz_infrared
@@ -1,0 +1,1 @@
+marantz


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  Pull requests for adding new custom components will no longer be accepted. Please refer to the Brands Proxy API announcement for more details:
  https://developers.home-assistant.io/blog/2026/02/24/brands-proxy-api
-->
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request.
-->

Adds a ``core_integrations/marantz_infrared`` symlink to the existing ``marantz`` brand so the new ``marantz_infrared`` core integration shares its logo and icons.


## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant Brands?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Add a new logo or icon for a new core integration
- [ ] Add a missing icon or logo for an existing core integration
- [ ] Replace an existing icon or logo with a higher quality version
- [ ] Replace an existing icon or logo after a branding change
- [ ] Removing an icon or logo

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- Link to code base pull request: https://github.com/home-assistant/core/pull/169626
- Link to documentation pull request: 
- Link to integration documentation on our website: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your contribution.
-->

- [ ] The added/replaced image(s) are **PNG**
- [ ] Icon image size is 256x256px (`icon.png`)
- [ ] hDPI icon image size is 512x512px for  (`icon@2x.png`)
- [ ] Logo image size has min 128px, but max 256px, on the shortest side (`logo.png`)
- [ ] hDPI logo image size has min 256px, but max 512px, on the shortest side (`logo@2x.png`)

This PR adds a symlink to the existing ``marantz`` brand rather than new image files, so the size checkboxes do not apply.

<!--
  Thank you for contributing <3
-->