### PR TITLE
Add Panasonic Window Air Conditioner (Hong Kong/Macau) brand

### DIFF
--- a/core_integrations/panasonic_window_ac_hk
+++ b/core_integrations/panasonic_window_ac_hk
@@ -1,0 +1,1 @@
+../core_brands/panasonic


### PR DESCRIPTION
## Proposed change

Adds the brand entry for the new `panasonic_window_ac_hk` core integration (Panasonic Window Air Conditioner sold in Hong Kong/Macau, controlled over the `infrared` platform).

This integration is grouped under the existing **Panasonic** brand, so `core_integrations/panasonic_window_ac_hk` is a symlink to `core_brands/panasonic`, reusing the existing Panasonic logo/icon — the same approach already used by `panasonic_bluray` and `panasonic_viera`. No new image assets are introduced.

## Type of change

- [x] Add a new logo or icon for a new core integration
- [ ] Add a missing icon or logo for an existing core integration
- [ ] Replace an existing icon or logo with a higher quality version
- [ ] Replace an existing icon or logo after a branding change
- [ ] Removing an icon or logo

## Additional information

- This PR fixes or closes issue: fixes #
- Link to code base pull request: https://github.com/home-assistant/core/pull/172642
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/45662
- Link to integration documentation on our website: https://www.home-assistant.io/integrations/panasonic_window_ac_hk

## Checklist

- [x] The added/replaced image(s) are **PNG**
- [x] Icon image size is 256x256px (`icon.png`)
- [x] hDPI icon image size is 512x512px for  (`icon@2x.png`)
- [x] Logo image size has min 128px, but max 256px, on the shortest side (`logo.png`)
- [x] hDPI logo image size has min 256px, but max 512px, on the shortest side (`logo@2x.png`)