### PR TITLE
Add missing icon for valve integration

### DIFF
--- a/custom_integrations/valve/icon.txt
+++ b/custom_integrations/valve/icon.txt
@@ -1,0 +1,1 @@
+mdi:valve-open


### PR DESCRIPTION

## Proposed change

Add missing icon for https://www.home-assistant.io/integrations/valve/

## Type of change

- [ ] Add a new logo or icon for a new core integration
- [x] Add a missing icon or logo for an existing core integration
- [ ] Replace an existing icon or logo with a higher quality version
- [ ] Replace an existing icon or logo after a branding change
- [ ] Removing an icon or logo

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: 
- Link to code base pull request: 
- Link to documentation pull request: 
- Link to integration documentation on our website: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your contribution.
-->

- [ ] The added/replaced image(s) are **PNG**
- [ ] Icon image size is 256x256px (`icon.png`)
- [ ] hDPI icon image size is 512x512px for  (`icon@2x.png`)
- [ ] Logo image size has min 128px, but max 256px, on the shortest side (`logo.png`)
- [ ] hDPI logo image size has min 256px, but max 512px, on the shortest side (`logo@2x.png`)

<!--
  Thank you for contributing <3
-->
