### PR TITLE
Add wiener_netze_smart_meter (Wiener Netze Smart Meter custom integration)

### DIFF
--- a/custom_integrations/wiener_netze_smart_meter/icon.png
+++ b/custom_integrations/wiener_netze_smart_meter/icon.png
@@ -1,0 +1,1 @@
+../wnsm/icon.png

--- a/custom_integrations/wiener_netze_smart_meter/logo.png
+++ b/custom_integrations/wiener_netze_smart_meter/logo.png
@@ -1,0 +1,1 @@
+../wnsm/logo.png


### PR DESCRIPTION
Adds a brand for the `wiener_netze_smart_meter` custom integration:
https://github.com/KrOnAsK/Wiener-Netze-Smart-Meter-API

This is a HACS custom integration for the official Wiener Netze Smart Meter API. It represents the same underlying service (Wiener Netze) as the existing `wnsm` integration, so it reuses the same brand. Per the duplicate-image guidance, the images are **symlinks** to the existing `custom_integrations/wnsm/` assets rather than duplicated bytes:

- `custom_integrations/wiener_netze_smart_meter/icon.png` -> `../wnsm/icon.png`
- `custom_integrations/wiener_netze_smart_meter/logo.png` -> `../wnsm/logo.png`

No new image bytes are introduced.