### PR TITLE
Remove unifiled brand

### DIFF
--- a/core_integrations/unifiled
+++ b/core_integrations/unifiled
@@ -1,1 +1,0 @@
-../core_brands/ubiquiti


### PR DESCRIPTION
The UniFi LED (`unifiled`) integration was removed from Home Assistant Core (home-assistant/core#168232), so its brand entry is now orphaned.

Remove the `core_integrations/unifiled` symlink. It pointed to the shared `core_brands/ubiquiti` brand, which stays — it's used by unifi, unifiprotect, and the other Ubiquiti integrations.

Docs removal: home-assistant/home-assistant.io#44776
