### PR TITLE
Add audiobookshelf_plus brand

### DIFF
--- a/custom_integrations/audiobookshelf_plus/icon.png
+++ b/custom_integrations/audiobookshelf_plus/icon.png
@@ -1,0 +1,1 @@
+../audiobookshelf/icon.png

--- a/custom_integrations/audiobookshelf_plus/icon@2x.png
+++ b/custom_integrations/audiobookshelf_plus/icon@2x.png
@@ -1,0 +1,1 @@
+../audiobookshelf/icon@2x.png


### PR DESCRIPTION
Adds the `audiobookshelf_plus` brand for a custom (HACS) integration for Audiobookshelf.

It uses the same Audiobookshelf product logo as the existing `audiobookshelf` custom integration, so `icon.png` and `icon@2x.png` are symlinked to that brand rather than duplicated.