### PR TITLE
Add color integration

### DIFF
--- a/core_integrations/color/icon.txt
+++ b/core_integrations/color/icon.txt
@@ -1,0 +1,1 @@
+mdi:palette


### PR DESCRIPTION
Adds the icon entry for the new `color` helper integration: home-assistant/core#177605

`icon.txt` with `mdi:palette`, matching the convention used by other helper integrations (schedule, derivative, threshold).

Proposal/context: https://github.com/orgs/home-assistant/discussions/1041

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DSnLnMp43HRSiDXyq8RGY3
